### PR TITLE
fix: Fixing class names for weapons

### DIFF
--- a/compats/compat_cup_weapons/models/l115a3.hpp
+++ b/compats/compat_cup_weapons/models/l115a3.hpp
@@ -1,8 +1,14 @@
-class CUP_L115A3 {
-	HDR(L115A3);
-	options[] = {"camo"};
+class CUP_srifle_AWM_blk {
+	model = "CUP_L115A3";
+	camo = "BLK";
+};
 
-	class camo: CUPCamo {
-		values[] = {"GRN", "BLK", "DST"};
-	};
+class CUP_srifle_AWM_wdl {
+	model = "CUP_L115A3";
+	camo = "GRN";	
+};
+
+class CUP_srifle_AWM_des {
+	model = "CUP_L115A3";
+	camo = "DST";
 };

--- a/compats/compat_cup_weapons/models/l129a1.hpp
+++ b/compats/compat_cup_weapons/models/l129a1.hpp
@@ -1,12 +1,59 @@
-class CUP_L129A1 {
-	HDR(L129A1);
-	options[] = {"camo", "ugl"};
+class CUP_srifle_L129A1 {
+	model = "CUP_L129A1";
+	camo = "BLK";
+	ugl = "None";
+};
 
-	class camo: CUPCamo {
-		values[] = {"BLK", "CTRGA", "CTRGT", "DST", "WDL"};
-	};
+class CUP_srifle_L129A1_ctrg {
+	model = "CUP_L129A1";
+	camo = "CTRGA";
+	ugl = "None";
+};
 
-	class ugl: CUPUGL {
-		values[] = {"None", "FG"};
-	};
+class CUP_srifle_L129A1_ctrgt {
+	model = "CUP_L129A1";
+	camo = "CTRGT";
+	ugl = "None";
+};
+
+class CUP_srifle_L129A1_d {
+	model = "CUP_L129A1";
+	camo = "DST";
+	ugl = "None";
+};
+
+class CUP_srifle_L129A1_HG_w {
+	model = "CUP_L129A1";
+	camo = "WDL";
+	ugl = "None";
+};
+
+class CUP_srifle_L129A1_HG_ctrg {
+	model = "CUP_L129A1";
+	camo = "BLK";
+	ugl = "FG";
+};
+
+class CUP_srifle_L129A1_HG {
+	model = "CUP_L129A1";
+	camo = "CTRGA";
+	ugl = "FG";
+};
+
+class CUP_srifle_L129A1_HG_ctrgt {
+	model = "CUP_L129A1";
+	camo = "CTRGT";
+	ugl = "FG";
+};
+
+class CUP_srifle_L129A1_HG_d {
+	model = "CUP_L129A1";
+	camo = "DST";
+	ugl = "FG";
+};
+
+class CUP_L129A1_Woodland_Foregrip {
+	model = "CUP_L129A1";
+	camo = "WDL";
+	ugl = "FG";
 };

--- a/compats/compat_cup_weapons/models/l7a2.hpp
+++ b/compats/compat_cup_weapons/models/l7a2.hpp
@@ -1,8 +1,9 @@
-class CUP_L7A2 {
-	HDR(L7A2);
-	options[] = {"rail"};
+class CUP_lmg_L7A2_flat {
+	model = "CUP_L7A2";
+	rail = "None";
+};
 
-	class rail: CUPRail {
-		values[] = {"None", "RIS"};
-	};
+class CUP_lmg_L7A2 {
+	model = "CUP_L7A2";
+	rail = "RIS";
 };

--- a/compats/compat_cup_weapons/models/l85a2.hpp
+++ b/compats/compat_cup_weapons/models/l85a2.hpp
@@ -1,12 +1,23 @@
 class CUP_L85A2 {
-	HDR(L85A2);
-	options[] = {"rail", "ugl"};
+	model = "CUP_L85A2";
+	rail = "None";
+	ugl = "None";
+};
 
-	class rail: CUPRail {
-		values[] = {"None", "RIS"};
-	};
+class CUP_L85A2_NG {
+	model = "CUP_L85A2";
+	rail = "RIS";
+	ugl = "None";
+};
 
-	class ugl: CUPUGL {
-		values[] = {"None", "FG", "L123A2"};
-	};
+class CUP_L85A2_G {
+	model = "CUP_L85A2";
+	rail = "None";
+	ugl = "FG";
+};
+
+class CUP_L85A2_GL {
+	model = "CUP_L85A2";
+	rail = "None";
+	ugl = "L123A2";
 };

--- a/compats/compat_cup_weapons/models/m1014.hpp
+++ b/compats/compat_cup_weapons/models/m1014.hpp
@@ -1,16 +1,34 @@
-class CUP_M1014 {
-	HDR(M1014);
-	options[] = {"length", "ugl", "stock"};
+class CUP_sgun_M1014 {
+	model = "CUP_M1014";
+	lenth = "Standard";
+	ugl = "None";
+	stock = "Standard";
+};
 
-	class length: CUPLength {
-		values[] = {"Standard", "Entry"};
-	};
+class CUP_sgun_M1014_Entry {
+	model = "CUP_M1014";
+	length = "Entry";
+	ugl = "None";
+	stock = "Standard";
+};
 
-	class ugl: CUPUGL {
-		values[] = {"None", "FG"};
-	};
+class CUP_sgun_M1014_vfg {
+	model = "CUP_M1014";
+	length = "Standard";
+	ugl = "FG";
+	stock = "Standard";
+};
 
-	class stock: CUPStock {
-		values[] = {"Standard", "Solid"};
-	};
+class CUP_sgun_M1014_solidstock {
+	model = "CUP_M1014";
+	length = "Standard";
+	ugl = "None";
+	stock = "Solid";
+};
+
+class CUP_sgun_M1014_Entry_vfg {
+	model = "CUP_M1014";
+	length = "Entry";
+	ugl = "FG";
+	stock = "Standard";
 };

--- a/compats/compat_cup_weapons/models/m107.hpp
+++ b/compats/compat_cup_weapons/models/m107.hpp
@@ -1,8 +1,24 @@
-class CUP_M107 {
-	HDR(M107);
-	options[] = {"camo"};
+class CUP_srifle_M107_Base {
+	model = "CUP_M107";
+	camo = "BLK";
+};
 
-	class camo: CUPCamo {
-		values[] = {"BLK", "DGREY", "DST", "WNT", "WDL"};
-	};
+class CUP_srifle_M107_Pristine {
+	model = "CUP_M107";
+	camo = "DGREY";
+};
+
+class CUP_srifle_M107_Desert {
+	model = "CUP_M107";
+	camo = "DST";
+};
+
+class CUP_srifle_M107_Snow {
+	model = "CUP_M107";
+	camo = "WNT";
+};
+
+class CUP_srifle_M107_Woodland {
+	model = "CUP_M107";
+	camo = "WDL";
 };

--- a/compats/compat_cup_weapons/models/m110.hpp
+++ b/compats/compat_cup_weapons/models/m110.hpp
@@ -1,12 +1,35 @@
-class CUP_M110 {
-	HDR(M110);
-	options[] = {"camo", "stock"};
+class CUP_srifle_m110_kac_black {
+	model = "CUP_M110";
+	camo = "BLK";
+	stock = "Standard";
+};
 
-	class camo: CUPCamo {
-		values[] = {"BLK", "TAN", "WDL"};
-	};
+class CUP_srifle_m110_kac {
+	model = "CUP_M110";
+	camo = "TAN";
+	stock = "Standard";
+};
 
-	class stock: CUPStock {
-		values[] = {"Standard", "PRS"};
-	};
+class CUP_srifle_m110_kac_woodland {
+	model = "CUP_M110";
+	camo = "WDL";
+	stock = "Standard";
+};
+
+class CUP_srifle_M110_black {
+	model = "CUP_M110";
+	camo = "BLK";
+	stock = "PRS";
+};
+
+class CUP_srifle_M110 {
+	model = "CUP_M110";
+	camo = "TAN";
+	stock = "PRS";
+};
+
+class CUP_srifle_M110_woodland {
+	model = "CUP_M110";
+	camo = "WDL";
+	stock = "PRS";
 };

--- a/compats/compat_cup_weapons/models/sa58.hpp
+++ b/compats/compat_cup_weapons/models/sa58.hpp
@@ -1,10 +1,19 @@
-class CUP_SA58 {
-	HDR(SA58);
-	options[] = {"rail"};
+class CUP_arifle_SA58_Klec {
+	model = "CUP_SA58";
+	rail = "None";
+};
 
-	class rail: CUPRail {
-		// Rear = Dust Cover.
-		// Front = Gas Tube.
-		values[] = {"None", "Rear", "Front", "RIS"};
-	};
+class CUP_arifle_SA58_Klec_rearris {
+	model = "CUP_SA58";
+	rail = "Rear";
+};
+
+class CUP_arifle_SA58_Klec_frontris {
+	model = "CUP_SA58";
+	rail = "Front";
+};
+
+class CUP_arifle_SA58_Klec_ris {
+	model = "CUP_SA58";
+	rail = "RIS";
 };


### PR DESCRIPTION
Fixed class names for the following weapons:
sa58, l115a3, l129a1, l7a2, l85, m1014, m107 and m110