### PR TITLE
fix: Fixing class names for weapons

### DIFF
--- a/compats/compat_cup_weapons/infos/l115a3.hpp
+++ b/compats/compat_cup_weapons/infos/l115a3.hpp
@@ -1,14 +1,14 @@
-class CUP_L115A3_Black {
+class CUP_srifle_AWM_blk {
 	model = "CUP_L115A3";
 	camo = "BLK";
 };
 
-class CUP_L115A3_Green {
+class CUP_srifle_AWM_wdl {
 	model = "CUP_L115A3";
 	camo = "GRN";	
 };
 
-class CUP_L115A3_Desert {
+class CUP_srifle_AWM_des {
 	model = "CUP_L115A3";
 	camo = "DST";
 };

--- a/compats/compat_cup_weapons/infos/l129a1.hpp
+++ b/compats/compat_cup_weapons/infos/l129a1.hpp
@@ -1,52 +1,52 @@
-class CUP_L129A1_Black {
+class CUP_srifle_L129A1 {
 	model = "CUP_L129A1";
 	camo = "BLK";
 	ugl = "None";
 };
 
-class CUP_L129A1_CTRGArid {
+class CUP_srifle_L129A1_ctrg {
 	model = "CUP_L129A1";
 	camo = "CTRGA";
 	ugl = "None";
 };
 
-class CUP_L129A1_CTRGTropical {
+class CUP_srifle_L129A1_ctrgt {
 	model = "CUP_L129A1";
 	camo = "CTRGT";
 	ugl = "None";
 };
 
-class CUP_L129A1_Desert {
+class CUP_srifle_L129A1_d {
 	model = "CUP_L129A1";
 	camo = "DST";
 	ugl = "None";
 };
 
-class CUP_L129A1_Woodland {
+class CUP_srifle_L129A1_HG_w {
 	model = "CUP_L129A1";
 	camo = "WDL";
 	ugl = "None";
 };
 
-class CUP_L129A1_Black_Foregrip {
+class CUP_srifle_L129A1_HG_ctrg {
 	model = "CUP_L129A1";
 	camo = "BLK";
 	ugl = "FG";
 };
 
-class CUP_L129A1_CTRGArid_Foregrip {
+class CUP_srifle_L129A1_HG {
 	model = "CUP_L129A1";
 	camo = "CTRGA";
 	ugl = "FG";
 };
 
-class CUP_L129A1_CTRGTropical_Foregrip {
+class CUP_srifle_L129A1_HG_ctrgt {
 	model = "CUP_L129A1";
 	camo = "CTRGT";
 	ugl = "FG";
 };
 
-class CUP_L129A1_Desert_Foregrip {
+class CUP_srifle_L129A1_HG_d {
 	model = "CUP_L129A1";
 	camo = "DST";
 	ugl = "FG";

--- a/compats/compat_cup_weapons/infos/l7a2.hpp
+++ b/compats/compat_cup_weapons/infos/l7a2.hpp
@@ -1,9 +1,9 @@
-class CUP_L7A2 {
+class CUP_lmg_L7A2_flat {
 	model = "CUP_L7A2";
 	rail = "None";
 };
 
-class CUP_L7A2_RIS {
+class CUP_lmg_L7A2 {
 	model = "CUP_L7A2";
 	rail = "RIS";
 };

--- a/compats/compat_cup_weapons/infos/l85a2.hpp
+++ b/compats/compat_cup_weapons/infos/l85a2.hpp
@@ -4,13 +4,13 @@ class CUP_L85A2 {
 	ugl = "None";
 };
 
-class CUP_L85A2_RIS {
+class CUP_L85A2_NG {
 	model = "CUP_L85A2";
 	rail = "RIS";
 	ugl = "None";
 };
 
-class CUP_L85A2_Foregrip {
+class CUP_L85A2_G {
 	model = "CUP_L85A2";
 	rail = "None";
 	ugl = "FG";
@@ -19,17 +19,5 @@ class CUP_L85A2_Foregrip {
 class CUP_L85A2_GL {
 	model = "CUP_L85A2";
 	rail = "None";
-	ugl = "L123A2";
-};
-
-class CUP_L85A2_RIS_Foregrip {
-	model = "CUP_L85A2";
-	rail = "RIS";
-	ugl = "FG";
-};
-
-class CUP_L85A2_RIS_GL {
-	model = "CUP_L85A2";
-	rail = "RIS";
 	ugl = "L123A2";
 };

--- a/compats/compat_cup_weapons/infos/m1014.hpp
+++ b/compats/compat_cup_weapons/infos/m1014.hpp
@@ -1,56 +1,34 @@
-class CUP_M1014 {
+class CUP_sgun_M1014 {
 	model = "CUP_M1014";
 	lenth = "Standard";
 	ugl = "None";
 	stock = "Standard";
 };
 
-class CUP_M1014_Entry {
+class CUP_sgun_M1014_Entry {
 	model = "CUP_M1014";
 	length = "Entry";
 	ugl = "None";
 	stock = "Standard";
 };
 
-class CUP_M1014_Foregrip {
+class CUP_sgun_M1014_vfg {
 	model = "CUP_M1014";
 	length = "Standard";
 	ugl = "FG";
 	stock = "Standard";
 };
 
-class CUP_M1014_SolidStock {
+class CUP_sgun_M1014_solidstock {
 	model = "CUP_M1014";
 	length = "Standard";
 	ugl = "None";
 	stock = "Solid";
 };
 
-class CUP_M1014_Entry_Foregrip {
+class CUP_sgun_M1014_Entry_vfg {
 	model = "CUP_M1014";
 	length = "Entry";
 	ugl = "FG";
 	stock = "Standard";
 };
-
-class CUP_M1014_Entry_SolidStock {
-	model = "CUP_M1014";
-	length = "Entry";
-	ugl = "None";
-	stock = "Solid";
-};
-
-class CUP_M1014_Foregrip_Solid {
-	model = "CUP_M1014";
-	length = "Standard";
-	ugl = "FG";
-	stock = "Solid";
-};
-
-class CUP_M1014_Entry_Foregrip_SolidStock {
-	model = "CUP_M1014";
-	length = "Entry";
-	ugl = "FG";
-	stock = "Solid";
-};
-

--- a/compats/compat_cup_weapons/infos/m107.hpp
+++ b/compats/compat_cup_weapons/infos/m107.hpp
@@ -1,24 +1,24 @@
-class CUP_M107_Black {
+class CUP_srifle_M107_Base {
 	model = "CUP_M107";
 	camo = "BLK";
 };
 
-class CUP_M107_Pristine {
+class CUP_srifle_M107_Pristine {
 	model = "CUP_M107";
 	camo = "DGREY";
 };
 
-class CUP_M107_Desert {
+class CUP_srifle_M107_Desert {
 	model = "CUP_M107";
 	camo = "DST";
 };
 
-class CUP_M107_Winter {
+class CUP_srifle_M107_Snow {
 	model = "CUP_M107";
 	camo = "WNT";
 };
 
-class CUP_M107_Woodland {
+class CUP_srifle_M107_Woodland {
 	model = "CUP_M107";
 	camo = "WDL";
 };

--- a/compats/compat_cup_weapons/infos/m110.hpp
+++ b/compats/compat_cup_weapons/infos/m110.hpp
@@ -1,34 +1,34 @@
-class CUP_M110_Black {
+class CUP_srifle_m110_kac_black {
 	model = "CUP_M110";
 	camo = "BLK";
 	stock = "Standard";
 };
 
-class CUP_M110_Tan {
+class CUP_srifle_m110_kac {
 	model = "CUP_M110";
 	camo = "TAN";
 	stock = "Standard";
 };
 
-class CUP_M110_Woodland {
+class CUP_srifle_m110_kac_woodland {
 	model = "CUP_M110";
 	camo = "WDL";
 	stock = "Standard";
 };
 
-class CUP_M110_Black_PRS {
+class CUP_srifle_M110_black {
 	model = "CUP_M110";
 	camo = "BLK";
 	stock = "PRS";
 };
 
-class CUP_M110_Tan_PRS {
+class CUP_srifle_M110 {
 	model = "CUP_M110";
 	camo = "TAN";
 	stock = "PRS";
 };
 
-class CUP_M110_Woodland_PRS {
+class CUP_srifle_M110_woodland {
 	model = "CUP_M110";
 	camo = "WDL";
 	stock = "PRS";

--- a/compats/compat_cup_weapons/infos/sa58.hpp
+++ b/compats/compat_cup_weapons/infos/sa58.hpp
@@ -1,19 +1,19 @@
-class CUP_SA58 {
+class CUP_arifle_SA58_Klec {
 	model = "CUP_SA58";
 	rail = "None";
 };
 
-class CUP_SA58_Dustcoverrail {
+class CUP_arifle_SA58_Klec_rearris {
 	model = "CUP_SA58";
 	rail = "Rear";
 };
 
-class CUP_SA58_Gastuberail {
+class CUP_arifle_SA58_Klec_frontris {
 	model = "CUP_SA58";
 	rail = "Front";
 };
 
-class CUP_SA58_RIS {
+class CUP_arifle_SA58_Klec_ris {
 	model = "CUP_SA58";
 	rail = "RIS";
 };


### PR DESCRIPTION
Fixed class names for the following weapons:
sa58, l115a3, l129a1, l7a2, l85, m1014, m107 and m110